### PR TITLE
fix: error in conversion when text does not contain Chinese

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,12 @@ const REGEXP = /[\u4E00-\u9FA5]/g
 const keys = Object.keys(dictionary)
 
 export default (str, options = {}) => {
-  let result = str.match(REGEXP).join('')
+  const temp = str.match(REGEXP)
+  if (temp === null) {
+    return str
+  }
+
+  let result = temp.join('')
 
   for (let key of keys) {
     if (~result.indexOf(key)) {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const keys = Object.keys(dictionary)
 
 export default (str, options = {}) => {
   const temp = str.match(REGEXP)
-  if (temp === null) {
+  if (!temp) {
     return str
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,12 @@ const REGEXP = /[\u4E00-\u9FA5]/g
 const keys = Object.keys(dictionary)
 
 export default (str, options = {}) => {
-  const temp = str.match(REGEXP)
-  if (!temp) {
+  let result = str.match(REGEXP)
+  if (!result) {
     return str
   }
 
-  let result = temp.join('')
+  result = result.join('')
 
   for (let key of keys) {
     if (~result.indexOf(key)) {


### PR DESCRIPTION
当我尝试用方法来翻译非中文字符串时，出现了未经处理的异常。

```js
const result = pinyin('Kevin Xiao', { keepRest: true, firstCharacter: true })
```

所以在转换前增加了`null`的校验，防止转换出错。